### PR TITLE
Add margin to wrapper on mobile

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -13,7 +13,7 @@ dl, dd, ol, ul, figure {
 /**
  * Basic styling
  */
-body {    
+body {
     font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
     color: $text-color;
     background-color: $background-color;
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-    margin-bottom: $spacing-unit / 2;    
+    margin-bottom: $spacing-unit / 2;
 }
 
 /**
@@ -103,7 +103,7 @@ a {
     }
 
     &:hover {
-        color: $text-color;        
+        color: $text-color;
     }
 }
 
@@ -172,6 +172,13 @@ pre {
         max-width:         calc(#{$content-width} - (#{$spacing-unit}));
         padding-right: $spacing-unit / 2;
         padding-left: $spacing-unit / 2;
+        margin-right: 20px;
+        margin-left: 20px;
+    }
+
+    @include media-query($on-palm) {
+        margin-right: 15px;
+        margin-left: 15px;
     }
 }
 


### PR DESCRIPTION
Love the theme, but wasn't crazy about how the text of posts would hit the edges on smaller width browsers. 

Added margin-left and margin-right for $on-laptop and $on-palm in _sass/base.scss

## Without margin (currently):

![bad](https://user-images.githubusercontent.com/19509185/29999315-7c1731e2-8ff8-11e7-82be-86d0d69d6c81.png)

## With margin (my branch): 
![good](https://user-images.githubusercontent.com/19509185/29999317-879a0c38-8ff8-11e7-8b04-2d0ed41a66d8.png)

